### PR TITLE
fixing build for luasql-odbc on Windows platforms

### DIFF
--- a/rockspec/luasql-odbc-2.6.0-3.rockspec
+++ b/rockspec/luasql-odbc-2.6.0-3.rockspec
@@ -1,0 +1,49 @@
+package = "LuaSQL-ODBC"
+version = "2.6.0-3"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git",
+  branch = "2.6.0",
+}
+description = {
+   summary = "Database connectivity for Lua (ODBC driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   ODBC = {
+      header = "sql.h"
+   }
+}
+build = {
+   type = "builtin",
+   platforms = {
+     windows = { 
+       modules = {
+         ["luasql.odbc"] = {
+           sources = { "src/luasql.c", "src/ls_odbc.c" },  
+           incdirs = { "$(ODBC_INCDIR)" },
+           libdirs = { "$(ODBC_LIBDIR)" },
+           libraries = { "odbc32" }
+         }
+       }
+     },
+     unix = { 
+       modules = {
+         ["luasql.odbc"] = {
+           sources = { "src/luasql.c", "src/ls_odbc.c" },  
+           incdirs = { "$(ODBC_INCDIR)" },
+           libdirs = { "$(ODBC_LIBDIR)" },
+           libraries = { "odbc" }
+         }
+       }
+     }
+   }
+}


### PR DESCRIPTION
added `platforms` switch for both windows and unix. Links `odbc32` to Windows and `odbc` to Unix.

Tested on Windows 10 and Ubuntu 20.04 (WSL version)