### PR TITLE
Fix Lua 5.4 incompatibilities by adding `LUASQL_NEWUD` macro for User data Creation

### DIFF
--- a/src/ls_firebird.c
+++ b/src/ls_firebird.c
@@ -19,6 +19,13 @@
 #define LUASQL_CONNECTION_FIREBIRD "Firebird connection"
 #define LUASQL_CURSOR_FIREBIRD "Firebird cursor"
 
+// Macro to handle userdata creation across Lua versions
+#if LUA_VERSION_NUM >= 504                        
+#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
+#else
+#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
+#endif
+
 typedef struct {
 	short closed;
 	ISC_STATUS status_vector[20];	/* for error results */
@@ -454,7 +461,7 @@ static int conn_execute (lua_State *L) {
 	/* what do we return? a cursor or a count */
 	if(cur.out_sqlda->sqld > 0) { /* a cursor */
 		char cur_name[32];
-		cur_data* user_cur = (cur_data*)lua_newuserdata(L, sizeof(cur_data));
+		cur_data* user_cur = (cur_data*)LUASQL_NEWUD(L, sizeof(cur_data));
 		luasql_setmeta (L, LUASQL_CURSOR_FIREBIRD);
 
 		sprintf(cur_name, "dyn_cursor_%p", (void *)user_cur);
@@ -923,7 +930,7 @@ static int create_environment (lua_State *L) {
 	int i;
 	env_data *env;
 
-	env = (env_data *)lua_newuserdata (L, sizeof (env_data));
+	env = (env_data *)LUASQL_NEWUD (L, sizeof (env_data));
 	luasql_setmeta (L, LUASQL_ENVIRONMENT_FIREBIRD);
 	/* fill in structure */
 	for(i=0; i<20; i++)
@@ -1000,7 +1007,7 @@ static int env_connect (lua_State *L) {
 		return return_db_error(L, conn.env->status_vector);
 
 	/* create the lua object and add the connection to the lock */
-	res_conn = (conn_data*)lua_newuserdata(L, sizeof(conn_data));
+	res_conn = (conn_data*)LUASQL_NEWUD(L, sizeof(conn_data));
 	luasql_setmeta (L, LUASQL_CONNECTION_FIREBIRD);
 	memcpy(res_conn, &conn, sizeof(conn_data));
 	res_conn->closed = 0;   /* connect now officially open */

--- a/src/ls_firebird.c
+++ b/src/ls_firebird.c
@@ -19,13 +19,6 @@
 #define LUASQL_CONNECTION_FIREBIRD "Firebird connection"
 #define LUASQL_CURSOR_FIREBIRD "Firebird cursor"
 
-// Macro to handle userdata creation across Lua versions
-#if LUA_VERSION_NUM >= 504                        
-#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
-#else
-#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
-#endif
-
 typedef struct {
 	short closed;
 	ISC_STATUS status_vector[20];	/* for error results */

--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -27,6 +27,13 @@
 #define LUASQL_CONNECTION_MYSQL "MySQL connection"
 #define LUASQL_CURSOR_MYSQL "MySQL cursor"
 
+// Macro to handle userdata creation across Lua versions
+#if LUA_VERSION_NUM >= 504                        
+#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
+#else
+#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
+#endif
+
 /* For compat with old version 4.0 */
 #if (MYSQL_VERSION_ID < 40100) 
 #define MYSQL_TYPE_VAR_STRING   FIELD_TYPE_VAR_STRING 
@@ -393,7 +400,7 @@ static int cur_seek (lua_State *L) {
 ** Create a new Cursor object and push it on top of the stack.
 */
 static int create_cursor (lua_State *L, MYSQL *my_conn, int conn, MYSQL_RES *result, int cols) {
-	cur_data *cur = (cur_data *)lua_newuserdata(L, sizeof(cur_data));
+	cur_data *cur = (cur_data *)LUASQL_NEWUD(L, sizeof(cur_data));
 	luasql_setmeta (L, LUASQL_CURSOR_MYSQL);
 
 	/* fill in structure */
@@ -559,7 +566,7 @@ static int conn_getlastautoid (lua_State *L) {
 ** Create a new Connection object and push it on top of the stack.
 */
 static int create_connection (lua_State *L, int env, MYSQL *const my_conn) {
-	conn_data *conn = (conn_data *)lua_newuserdata(L, sizeof(conn_data));
+	conn_data *conn = (conn_data *)LUASQL_NEWUD(L, sizeof(conn_data));
 	luasql_setmeta (L, LUASQL_CONNECTION_MYSQL);
 
 	/* fill in structure */
@@ -677,7 +684,7 @@ static void create_metatables (lua_State *L) {
 ** Creates an Environment and returns it.
 */
 static int create_environment (lua_State *L) {
-	env_data *env = (env_data *)lua_newuserdata(L, sizeof(env_data));
+	env_data *env = (env_data *)LUASQL_NEWUD(L, sizeof(env_data));
 	luasql_setmeta (L, LUASQL_ENVIRONMENT_MYSQL);
 
 	/* fill in structure */

--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -27,13 +27,6 @@
 #define LUASQL_CONNECTION_MYSQL "MySQL connection"
 #define LUASQL_CURSOR_MYSQL "MySQL cursor"
 
-// Macro to handle userdata creation across Lua versions
-#if LUA_VERSION_NUM >= 504                        
-#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
-#else
-#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
-#endif
-
 /* For compat with old version 4.0 */
 #if (MYSQL_VERSION_ID < 40100) 
 #define MYSQL_TYPE_VAR_STRING   FIELD_TYPE_VAR_STRING 

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -24,6 +24,12 @@
 #define LUASQL_CONNECTION_OCI8 "Oracle connection"
 #define LUASQL_CURSOR_OCI8 "Oracle cursor"
 
+// Macro to handle userdata creation across Lua versions
+#if LUA_VERSION_NUM >= 504                        
+#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
+#else
+#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
+#endif
 
 typedef struct {
 	short         closed;
@@ -554,7 +560,7 @@ static int conn_close (lua_State *L) {
 static int create_cursor (lua_State *L, int o, conn_data *conn, OCIStmt *stmt, const char *text) {
 	int i;
 	env_data *env;
-	cur_data *cur = (cur_data *)lua_newuserdata(L, sizeof(cur_data));
+	cur_data *cur = (cur_data *)LUASQL_NEWUD(L, sizeof(cur_data));
 	luasql_setmeta (L, LUASQL_CURSOR_OCI8);
 
 	conn->cur_counter++;
@@ -726,7 +732,7 @@ static int env_connect (lua_State *L) {
 	size_t userlen = (username) ? strlen(username) : 0;
 	size_t passlen = (password) ? strlen(password) : 0;
 	/* Alloc connection object */
-	conn_data *conn = (conn_data *)lua_newuserdata(L, sizeof(conn_data));
+	conn_data *conn = (conn_data *)LUASQL_NEWUD(L, sizeof(conn_data));
 
 	/* fill in structure */
 	luasql_setmeta (L, LUASQL_CONNECTION_OCI8);
@@ -790,7 +796,7 @@ static int env_close (lua_State *L) {
 ** Creates an Environment and returns it.
 */
 static int create_environment (lua_State *L) {
-	env_data *env = (env_data *)lua_newuserdata(L, sizeof(env_data));
+	env_data *env = (env_data *)LUASQL_NEWUD(L, sizeof(env_data));
 	luasql_setmeta (L, LUASQL_ENVIRONMENT_OCI8);
 	/* fill in structure */
 	env->closed = 0;

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -24,13 +24,6 @@
 #define LUASQL_CONNECTION_OCI8 "Oracle connection"
 #define LUASQL_CURSOR_OCI8 "Oracle cursor"
 
-// Macro to handle userdata creation across Lua versions
-#if LUA_VERSION_NUM >= 504                        
-#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
-#else
-#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
-#endif
-
 typedef struct {
 	short         closed;
 	int           conn_counter;

--- a/src/ls_odbc.c
+++ b/src/ls_odbc.c
@@ -32,6 +32,13 @@
 #define LUASQL_STATEMENT_ODBC "ODBC statement"
 #define LUASQL_CURSOR_ODBC "ODBC cursor"
 
+// Macro to handle userdata creation across Lua versions
+#if LUA_VERSION_NUM >= 504                        
+#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
+#else
+#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
+#endif
+
 /* holds data for parameter binding */
 typedef struct {
 	SQLPOINTER buf;
@@ -577,7 +584,7 @@ static int create_cursor (lua_State *L, int stmt_i, stmt_data *stmt,
 
 	lock_obj(L, stmt_i, stmt);
 
-	cur = (cur_data *) lua_newuserdata(L, sizeof(cur_data));
+	cur = (cur_data *) LUASQL_NEWUD(L, sizeof(cur_data));
 	luasql_setmeta (L, LUASQL_CURSOR_ODBC);
 
 	/* fill in structure */
@@ -912,7 +919,7 @@ static int conn_prepare(lua_State *L)
 		return ret;
 	}
 
-	stmt = (stmt_data *)lua_newuserdata(L, sizeof(stmt_data));
+	stmt = (stmt_data *)LUASQL_NEWUD(L, sizeof(stmt_data));
 	memset(stmt, 0, sizeof(stmt_data));
 
 	stmt->closed = 0;
@@ -1037,7 +1044,7 @@ static int conn_setautocommit (lua_State *L) {
 */
 static int create_connection (lua_State *L, int o, env_data *env, SQLHDBC hdbc)
 {
-	conn_data *conn = (conn_data *)lua_newuserdata(L, sizeof(conn_data));
+	conn_data *conn = (conn_data *)LUASQL_NEWUD(L, sizeof(conn_data));
 
 	/* set auto commit mode */
 	SQLRETURN ret = SQLSetConnectAttr(hdbc, SQL_ATTR_AUTOCOMMIT,
@@ -1184,7 +1191,7 @@ static int create_environment (lua_State *L)
 		return ret;
 	}
 
-	env = (env_data *)lua_newuserdata (L, sizeof (env_data));
+	env = (env_data *)LUASQL_NEWUD (L, sizeof (env_data));
 	luasql_setmeta (L, LUASQL_ENVIRONMENT_ODBC);
 	/* fill in structure */
 	env->closed = 0;

--- a/src/ls_odbc.c
+++ b/src/ls_odbc.c
@@ -32,13 +32,6 @@
 #define LUASQL_STATEMENT_ODBC "ODBC statement"
 #define LUASQL_CURSOR_ODBC "ODBC cursor"
 
-// Macro to handle userdata creation across Lua versions
-#if LUA_VERSION_NUM >= 504                        
-#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
-#else
-#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
-#endif
-
 /* holds data for parameter binding */
 typedef struct {
 	SQLPOINTER buf;

--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -23,6 +23,13 @@
 #define LUASQL_CONNECTION_PG "PostgreSQL connection"
 #define LUASQL_CURSOR_PG "PostgreSQL cursor"
 
+// Macro to handle userdata creation across Lua versions
+#if LUA_VERSION_NUM >= 504                        
+#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
+#else
+#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
+#endif
+
 typedef struct {
 	short      closed;
 } env_data;
@@ -292,7 +299,7 @@ static int cur_numrows (lua_State *L) {
 ** Create a new Cursor object and push it on top of the stack.
 */
 static int create_cursor (lua_State *L, int conn, PGresult *result) {
-	cur_data *cur = (cur_data *)lua_newuserdata(L, sizeof(cur_data));
+	cur_data *cur = (cur_data *)LUASQL_NEWUD(L, sizeof(cur_data));
 	luasql_setmeta (L, LUASQL_CURSOR_PG);
 
 	/* fill in structure */
@@ -482,7 +489,7 @@ static int conn_setautocommit (lua_State *L) {
 ** Create a new Connection object and push it on top of the stack.
 */
 static int create_connection (lua_State *L, int env, PGconn *const pg_conn) {
-	conn_data *conn = (conn_data *)lua_newuserdata(L, sizeof(conn_data));
+	conn_data *conn = (conn_data *)LUASQL_NEWUD(L, sizeof(conn_data));
 	luasql_setmeta (L, LUASQL_CONNECTION_PG);
 
 	/* fill in structure */
@@ -595,7 +602,7 @@ static void create_metatables (lua_State *L) {
 ** Creates an Environment and returns it.
 */
 static int create_environment (lua_State *L) {
-	env_data *env = (env_data *)lua_newuserdata(L, sizeof(env_data));
+	env_data *env = (env_data *)LUASQL_NEWUD(L, sizeof(env_data));
 	luasql_setmeta (L, LUASQL_ENVIRONMENT_PG);
 
 	/* fill in structure */

--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -23,13 +23,6 @@
 #define LUASQL_CONNECTION_PG "PostgreSQL connection"
 #define LUASQL_CURSOR_PG "PostgreSQL cursor"
 
-// Macro to handle userdata creation across Lua versions
-#if LUA_VERSION_NUM >= 504                        
-#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
-#else
-#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
-#endif
-
 typedef struct {
 	short      closed;
 } env_data;

--- a/src/ls_sqlite.c
+++ b/src/ls_sqlite.c
@@ -20,13 +20,6 @@
 #define LUASQL_CONNECTION_SQLITE "SQLite connection"
 #define LUASQL_CURSOR_SQLITE "SQLite cursor"
 
-// Macro to handle userdata creation across Lua versions
-#if LUA_VERSION_NUM >= 504                        
-#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
-#else
-#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
-#endif
-
 typedef struct {
 	short       closed;
 } env_data;

--- a/src/ls_sqlite.c
+++ b/src/ls_sqlite.c
@@ -20,6 +20,13 @@
 #define LUASQL_CONNECTION_SQLITE "SQLite connection"
 #define LUASQL_CURSOR_SQLITE "SQLite cursor"
 
+// Macro to handle userdata creation across Lua versions
+#if LUA_VERSION_NUM >= 504                        
+#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
+#else
+#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
+#endif
+
 typedef struct {
 	short       closed;
 } env_data;
@@ -235,7 +242,7 @@ static int create_cursor(lua_State *L, int o, conn_data *conn,
 		sqlite_vm *sql_vm, int numcols, const char **col_info)
 {
 	int i;
-	cur_data *cur = (cur_data*)lua_newuserdata(L, sizeof(cur_data));
+	cur_data *cur = (cur_data*)LUASQL_NEWUD(L, sizeof(cur_data));
 	luasql_setmeta (L, LUASQL_CURSOR_SQLITE);
 
 	/* increment cursor count for the connection creating this cursor */
@@ -447,7 +454,7 @@ static int conn_setautocommit(lua_State *L) {
 ** Create a new Connection object and push it on top of the stack.
 */
 static int create_connection(lua_State *L, int env, sqlite *sql_conn) {
-	conn_data *conn = (conn_data*)lua_newuserdata(L, sizeof(conn_data));
+	conn_data *conn = (conn_data*)LUASQL_NEWUD(L, sizeof(conn_data));
 	luasql_setmeta(L, LUASQL_CONNECTION_SQLITE);
 
 	/* fill in structure */
@@ -562,7 +569,7 @@ static void create_metatables (lua_State *L) {
 ** Creates an Environment and returns it.
 */
 static int create_environment (lua_State *L) {
-	env_data *env = (env_data *)lua_newuserdata(L, sizeof(env_data));
+	env_data *env = (env_data *)LUASQL_NEWUD(L, sizeof(env_data));
 	luasql_setmeta(L, LUASQL_ENVIRONMENT_SQLITE);
 
 	/* fill in structure */

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -22,13 +22,6 @@
 #define LUASQL_CONNECTION_SQLITE "SQLite3 connection"
 #define LUASQL_CURSOR_SQLITE "SQLite3 cursor"
 
-// Macro to handle userdata creation across Lua versions
-#if LUA_VERSION_NUM >= 504                        
-#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
-#else
-#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
-#endif
-
 typedef struct
 {
   short       closed;

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -22,6 +22,13 @@
 #define LUASQL_CONNECTION_SQLITE "SQLite3 connection"
 #define LUASQL_CURSOR_SQLITE "SQLite3 cursor"
 
+// Macro to handle userdata creation across Lua versions
+#if LUA_VERSION_NUM >= 504                        
+#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
+#else
+#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
+#endif
+
 typedef struct
 {
   short       closed;
@@ -276,11 +283,7 @@ static int create_cursor(lua_State *L, int o, conn_data *conn,
 			 sqlite3_stmt *sql_vm, int numcols)
 {
   int i;
-#if LUA_VERSION_NUM >= 504
-    cur_data *cur = (cur_data*)lua_newuserdatauv(L, sizeof(cur_data), 0);
-#else 
-    cur_data *cur = (cur_data*)lua_newuserdata(L, sizeof(cur_data));
-#endif
+  cur_data *cur = (cur_data*)LUASQL_NEWUD(L, sizeof(cur_data));
   luasql_setmeta (L, LUASQL_CURSOR_SQLITE);
 
   /* increment cursor count for the connection creating this cursor */
@@ -642,11 +645,7 @@ static int conn_setautocommit(lua_State *L)
 */
 static int create_connection(lua_State *L, int env, sqlite3 *sql_conn)
 {
-#if LUA_VERSION_NUM >= 504
-    conn_data *conn = (conn_data*)lua_newuserdatauv(L, sizeof(conn_data), 0);
-#else
-    conn_data *conn = (conn_data*)lua_newuserdata(L, sizeof(conn_data));
-#endif
+  conn_data *conn = (conn_data*)LUASQL_NEWUD(L, sizeof(conn_data));
   luasql_setmeta(L, LUASQL_CONNECTION_SQLITE);
 
   /* fill in structure */
@@ -801,11 +800,7 @@ static void create_metatables (lua_State *L)
 */
 static int create_environment (lua_State *L)
 {
-#if LUA_VERSION_NUM >= 504
-    env_data *env = (env_data*)lua_newuserdatauv(L, sizeof(env_data), 0);
-#else
-    env_data *env = (env_data*)lua_newuserdata(L, sizeof(env_data));
-#endif
+  env_data *env = (env_data *)LUASQL_NEWUD(L, sizeof(env_data));
   luasql_setmeta(L, LUASQL_ENVIRONMENT_SQLITE);
 
   /* fill in structure */

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -276,7 +276,11 @@ static int create_cursor(lua_State *L, int o, conn_data *conn,
 			 sqlite3_stmt *sql_vm, int numcols)
 {
   int i;
-  cur_data *cur = (cur_data*)lua_newuserdata(L, sizeof(cur_data));
+#if LUA_VERSION_NUM >= 504
+    cur_data *cur = (cur_data*)lua_newuserdatauv(L, sizeof(cur_data), 0);
+#else 
+    cur_data *cur = (cur_data*)lua_newuserdata(L, sizeof(cur_data));
+#endif
   luasql_setmeta (L, LUASQL_CURSOR_SQLITE);
 
   /* increment cursor count for the connection creating this cursor */
@@ -638,7 +642,11 @@ static int conn_setautocommit(lua_State *L)
 */
 static int create_connection(lua_State *L, int env, sqlite3 *sql_conn)
 {
-  conn_data *conn = (conn_data*)lua_newuserdata(L, sizeof(conn_data));
+#if LUA_VERSION_NUM >= 504
+    conn_data *conn = (conn_data*)lua_newuserdatauv(L, sizeof(conn_data), 0);
+#else
+    conn_data *conn = (conn_data*)lua_newuserdata(L, sizeof(conn_data));
+#endif
   luasql_setmeta(L, LUASQL_CONNECTION_SQLITE);
 
   /* fill in structure */
@@ -793,7 +801,11 @@ static void create_metatables (lua_State *L)
 */
 static int create_environment (lua_State *L)
 {
-  env_data *env = (env_data *)lua_newuserdata(L, sizeof(env_data));
+#if LUA_VERSION_NUM >= 504
+    env_data *env = (env_data*)lua_newuserdatauv(L, sizeof(env_data), 0);
+#else
+    env_data *env = (env_data*)lua_newuserdata(L, sizeof(env_data));
+#endif
   luasql_setmeta(L, LUASQL_ENVIRONMENT_SQLITE);
 
   /* fill in structure */

--- a/src/luasql.h
+++ b/src/luasql.h
@@ -24,6 +24,13 @@
 #define LUASQL_CONNECTION "Each driver must have a connection metatable"
 #define LUASQL_CURSOR "Each driver must have a cursor metatable"
 
+// Macro to handle userdata creation across Lua versions
+#if LUA_VERSION_NUM >= 504                        
+#define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
+#else
+#define LUASQL_NEWUD(L, size) lua_newuserdata(L, size)
+#endif
+
 LUASQL_API int luasql_faildirect (lua_State *L, const char *err);
 LUASQL_API int luasql_failmsg (lua_State *L, const char *err, const char *m);
 LUASQL_API int luasql_createmeta (lua_State *L, const char *name, const luaL_Reg *methods);


### PR DESCRIPTION
## Summary
This pull request addresses the incompatibilities introduced in Lua 5.4, where `lua_newuserdata` was replaced by `lua_newuserdatauv`

## Proposed changes
- Introduced `LUASQL_NEWUD` macro to abstract the differences between `lua_newuserdata` and `lua_newuserdatauv`. 
This change improves code readability and reduces redundancy by centralizing the version check and userdata creation logic.
- Updated all drivers to use the `LUASQL_NEWUD` macro for consistent and version-agnostic userdata creation.