### PR TITLE
Driver Adaptation to `To-be-Closed` variables and Enhancement of Test Suite 

### DIFF
--- a/src/ls_firebird.c
+++ b/src/ls_firebird.c
@@ -1056,12 +1056,14 @@ static int env_gc (lua_State *L) {
 static void create_metatables (lua_State *L) {
 	struct luaL_Reg environment_methods[] = {
 		{"__gc", env_gc},
+		{"__close", env_close},
 		{"close", env_close},
 		{"connect", env_connect},
 		{NULL, NULL},
 	};
 	struct luaL_Reg connection_methods[] = {
 		{"__gc", conn_gc},
+		{"__close", conn_close},
 		{"close", conn_close},
 		{"execute", conn_execute},
 		{"commit", conn_commit},
@@ -1072,6 +1074,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg cursor_methods[] = {
 		{"__gc", cur_gc},
+		{"__close", cur_close},
 		{"close", cur_close},
 		{"fetch", cur_fetch},
 		{"getcoltypes", cur_coltypes},

--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -638,12 +638,14 @@ static int env_close (lua_State *L) {
 static void create_metatables (lua_State *L) {
     struct luaL_Reg environment_methods[] = {
         {"__gc", env_gc},
+		{"__close", env_close},
         {"close", env_close},
         {"connect", env_connect},
 		{NULL, NULL},
 	};
     struct luaL_Reg connection_methods[] = {
         {"__gc", conn_gc},
+		{"__close", conn_close},
         {"close", conn_close},
         {"ping", conn_ping},
         {"escape", escape_string},
@@ -656,6 +658,7 @@ static void create_metatables (lua_State *L) {
     };
     struct luaL_Reg cursor_methods[] = {
         {"__gc", cur_gc},
+		{"__close", cur_close},
         {"close", cur_close},
         {"getcolnames", cur_getcolnames},
         {"getcoltypes", cur_getcoltypes},

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -818,12 +818,14 @@ static int create_environment (lua_State *L) {
 static void create_metatables (lua_State *L) {
 	struct luaL_Reg environment_methods[] = {
 		{"__gc", env_close}, /* Should this method be changed? */
+		{"__close", env_close},
 		{"close", env_close},
 		{"connect", env_connect},
 		{NULL, NULL},
 	};
 	struct luaL_Reg connection_methods[] = {
 		{"__gc", conn_close}, /* Should this method be changed? */
+		{"__close", conn_close},
 		{"close", conn_close},
 		{"execute", conn_execute},
 		{"commit", conn_commit},
@@ -833,6 +835,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg cursor_methods[] = {
 		{"__gc", cur_close}, /* Should this method be changed? */
+		{"__close", cur_close},
 		{"close", cur_close},
 		{"getcolnames", cur_getcolnames},
 		{"getcoltypes", cur_getcoltypes},

--- a/src/ls_odbc.c
+++ b/src/ls_odbc.c
@@ -1128,12 +1128,14 @@ static int env_close (lua_State *L)
 static void create_metatables (lua_State *L) {
 	struct luaL_Reg environment_methods[] = {
 		{"__gc", env_close}, /* Should this method be changed? */
+		{"__close", env_close},
 		{"close", env_close},
 		{"connect", env_connect},
 		{NULL, NULL},
 	};
 	struct luaL_Reg connection_methods[] = {
 		{"__gc", conn_close}, /* Should this method be changed? */
+		{"__close", conn_close},
 		{"close", conn_close},
 		{"prepare", conn_prepare},
 		{"execute", conn_execute},
@@ -1144,6 +1146,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg statement_methods[] = {
 		{"__gc", stmt_close}, /* Should this method be changed? */
+		{"__close", stmt_close},
 		{"close", stmt_close},
 		{"execute", stmt_execute},
 		{"getparamtypes", stmt_paramtypes},
@@ -1151,6 +1154,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg cursor_methods[] = {
 		{"__gc", cur_close}, /* Should this method be changed? */
+		{"__close", cur_close},
 		{"close", cur_close},
 		{"fetch", cur_fetch},
 		{"getcoltypes", cur_coltypes},

--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -562,12 +562,14 @@ static int env_close (lua_State *L) {
 static void create_metatables (lua_State *L) {
 	struct luaL_Reg environment_methods[] = {
 		{"__gc",    env_gc},
+		{"__close", env_close},
 		{"close",   env_close},
 		{"connect", env_connect},
 		{NULL, NULL},
 	};
 	struct luaL_Reg connection_methods[] = {
 		{"__gc",          conn_gc},
+		{"__close", 	  conn_close},
 		{"close",         conn_close},
 		{"escape",        conn_escape},
 		{"execute",       conn_execute},
@@ -578,6 +580,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg cursor_methods[] = {
 		{"__gc",        cur_gc},
+		{"__close", 	cur_close},
 		{"close",       cur_close},
 		{"getcolnames", cur_getcolnames},
 		{"getcoltypes", cur_getcoltypes},

--- a/src/ls_sqlite.c
+++ b/src/ls_sqlite.c
@@ -530,12 +530,14 @@ static int conn_escape(lua_State *L) {
 static void create_metatables (lua_State *L) {
 	struct luaL_Reg environment_methods[] = {
 		{"__gc", env_gc},
+		{"__close", env_close},
 		{"close", env_close},
 		{"connect", env_connect},
 		{NULL, NULL},
 	};
 	struct luaL_Reg connection_methods[] = {
 		{"__gc", conn_gc},
+		{"__close", conn_close},
 		{"close", conn_close},
 		{"escape", conn_escape},
 		{"execute", conn_execute},
@@ -546,6 +548,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg cursor_methods[] = {
 		{"__gc", cur_gc},
+		{"__close", cur_close},
 		{"close", cur_close},
 		{"getcolnames", cur_getcolnames},
 		{"getcoltypes", cur_getcoltypes},

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -758,12 +758,14 @@ static void create_metatables (lua_State *L)
 {
   struct luaL_Reg environment_methods[] = {
     {"__gc", env_gc},
+    {"__close", env_close},
     {"close", env_close},
     {"connect", env_connect},
     {NULL, NULL},
   };
   struct luaL_Reg connection_methods[] = {
     {"__gc", conn_gc},
+    {"__close", conn_close},
     {"close", conn_close},
     {"escape", conn_escape},
 //    {"prepare", conn_prepare},
@@ -776,6 +778,7 @@ static void create_metatables (lua_State *L)
   };
   struct luaL_Reg cursor_methods[] = {
     {"__gc", cur_gc},
+    {"__close", cur_close},
     {"close", cur_close},
     {"getcolnames", cur_getcolnames},
     {"getcoltypes", cur_getcoltypes},

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -385,32 +385,33 @@ static int set_param(lua_State *L, sqlite3_stmt *vm, int param_nr, int arg)
     break;
 
     case LUA_TSTRING: {
-    size_t s_len;
-    const char *s = lua_tolstring(L, arg, &s_len);
-    rc = sqlite3_bind_null(vm, param_nr);
-    rc = sqlite3_bind_text(vm, param_nr, s, s_len, SQLITE_TRANSIENT);
-    break;
+      size_t s_len;
+      const char *s = lua_tolstring(L, arg, &s_len);
+      rc = sqlite3_bind_null(vm, param_nr);
+      rc = sqlite3_bind_text(vm, param_nr, s, s_len, SQLITE_TRANSIENT);
+      break;
     }
 
     case LUA_TBOOLEAN: {
       int val = lua_tointeger(L, arg);
       rc = sqlite3_bind_int(vm, param_nr, val);
+      break;
     }
-    break;
 
-    case LUA_TNUMBER:
+    case LUA_TNUMBER: {
 #if defined(lua_isinteger)
-    if (lua_isinteger(L, arg)) {
-      lua_Integer val = lua_tointeger(L, arg);
-      rc = sqlite3_bind_int64(vm, param_nr, val);
-    } else {
+      if (lua_isinteger(L, arg)) {
+        lua_Integer val = lua_tointeger(L, arg);
+        rc = sqlite3_bind_int64(vm, param_nr, val);
+      } else {
 #endif
-      double val = lua_tonumber(L, arg);
-      rc = sqlite3_bind_double(vm, param_nr, val);
+        double val = lua_tonumber(L, arg);
+        rc = sqlite3_bind_double(vm, param_nr, val);
 #if defined(lua_isinteger)
+      }
+#endif
+      break;
     }
-#endif
-    break;
 
     default:
     luaL_error(L, LUASQL_PREFIX"unhandled data type %s in parameter binding",

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -99,15 +99,15 @@ function test_object (obj, objmethods)
 	return obj
 end
 
-ENV_METHODS = { "close", "connect", }
+ENV_METHODS = { "close", "connect", "__close", }
 ENV_OK = function (obj)
 	return test_object (obj, ENV_METHODS)
 end
-CONN_METHODS = { "close", "commit", "execute", "rollback", "setautocommit", }
+CONN_METHODS = { "close", "commit", "execute", "rollback", "setautocommit", "__close", }
 CONN_OK = function (obj)
 	return test_object (obj, CONN_METHODS)
 end
-CUR_METHODS = { "close", "fetch", "getcolnames", "getcoltypes", }
+CUR_METHODS = { "close", "fetch", "getcolnames", "getcoltypes", "__close", }
 CUR_OK = function (obj)
 	return test_object (obj, CUR_METHODS)
 end
@@ -476,6 +476,7 @@ function column_info ()
 	for i = 1, table.getn(names) do
 		assert2 ("f"..i, string.lower(names[i]), "incorrect column names table")
 		local type_i = types[i]
+		type_i = string.lower(type_i)
 		assert (type_i == QUERYING_STRING_TYPE_NAME, "incorrect column types table")
 	end
 	-- check if the tables are being reused.
@@ -546,6 +547,12 @@ function check_close()
 	assert (cur:fetch(), "corrupted cursor")
 	cur:close ()
 	conn:close ()
+end
+
+---------------------------------------------------------------------
+---------------------------------------------------------------------
+function to_be_closed_support ()
+       assert (loadfile"to_be_closed_support.lua")()
 end
 
 ---------------------------------------------------------------------
@@ -677,6 +684,9 @@ if string.find(_VERSION, " 5.0") then
 	end
 else
 	luasql = require ("luasql."..driver)
+	if string.find(_VERSION, " 5.4") then
+		table.insert (tests, 10, { "to-be-closed support", to_be_closed_support })
+	end
 end
 assert (luasql, "Could not load driver: no luasql table.")
 io.write (luasql._VERSION.." "..driver)

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -99,15 +99,15 @@ function test_object (obj, objmethods)
 	return obj
 end
 
-ENV_METHODS = { "close", "connect", "__close", }
+ENV_METHODS = { "close", "connect", }
 ENV_OK = function (obj)
 	return test_object (obj, ENV_METHODS)
 end
-CONN_METHODS = { "close", "commit", "execute", "rollback", "setautocommit", "__close", }
+CONN_METHODS = { "close", "commit", "execute", "rollback", "setautocommit", }
 CONN_OK = function (obj)
 	return test_object (obj, CONN_METHODS)
 end
-CUR_METHODS = { "close", "fetch", "getcolnames", "getcoltypes", "__close", }
+CUR_METHODS = { "close", "fetch", "getcolnames", "getcoltypes", }
 CUR_OK = function (obj)
 	return test_object (obj, CUR_METHODS)
 end

--- a/tests/to_be_closed_support.lua
+++ b/tests/to_be_closed_support.lua
@@ -1,0 +1,14 @@
+---------------------------------------------------------------------
+-- Lua 5.4 support to to-be-closed variables.
+---------------------------------------------------------------------
+
+assert(CONN, "Unable to access CONN variable with a connection object!")
+
+local cursor <close> = CONN:execute("select * from t")
+CUR_OK (cursor)
+
+local connection <close> = ENV:connect (datasource, username, password)
+CONN_OK (connection)
+
+local environment <close> = luasql[driver] () 
+ENV_OK (environment)


### PR DESCRIPTION
## Summary
This pull request addresses the Adaptation of LuaSQL drivers to `to-be-closed` variables introduced in Lua 5.4 

## Proposed Changes 
- Added `__close` metamethod to `cursor`, `connection` and `environment` objects of drivers to make them compatible to to-be-closed variation of objects 
- Added Test Suite to test `to-be-closed support` of LuaSQL Drivers
- Added Correction on compilation messages