### PR TITLE
Refactor Resource cleanup methods of LuaSQL Drivers

### DIFF
--- a/src/ls_firebird.c
+++ b/src/ls_firebird.c
@@ -551,7 +551,8 @@ static int conn_close (lua_State *L) {
 	/* already closed */
 	if(conn->closed != 0) {
 		lua_pushboolean(L, 0);
-		return 1;
+		lua_pushstring(L, "Connection is already closed");
+		return 2;
 	}
 
 	/* are all related cursors closed? */
@@ -899,7 +900,8 @@ static int cur_close (lua_State *L) {
 	}
 
 	lua_pushboolean(L, 0);
-	return 1;
+	lua_pushstring(L, "cursor is already closed");
+	return 2;
 }
 
 /*
@@ -1023,9 +1025,10 @@ static int env_close (lua_State *L) {
 	luaL_argcheck (L, env != NULL, 1, "environment expected");
 	
 	/* already closed? */
-	if(env->closed == 1) {
+	if(env->closed) {
 		lua_pushboolean(L, 0);
-		return 1;
+		lua_pushstring(L, "env is already closed");
+		return 2;
 	}
 
 	/* check the lock */
@@ -1056,14 +1059,14 @@ static int env_gc (lua_State *L) {
 static void create_metatables (lua_State *L) {
 	struct luaL_Reg environment_methods[] = {
 		{"__gc", env_gc},
-		{"__close", env_close},
+		{"__close", env_gc},
 		{"close", env_close},
 		{"connect", env_connect},
 		{NULL, NULL},
 	};
 	struct luaL_Reg connection_methods[] = {
 		{"__gc", conn_gc},
-		{"__close", conn_close},
+		{"__close", conn_gc},
 		{"close", conn_close},
 		{"execute", conn_execute},
 		{"commit", conn_commit},
@@ -1074,7 +1077,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg cursor_methods[] = {
 		{"__gc", cur_gc},
-		{"__close", cur_close},
+		{"__close", cur_gc},
 		{"close", cur_close},
 		{"fetch", cur_fetch},
 		{"getcoltypes", cur_coltypes},

--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -325,7 +325,8 @@ static int cur_close (lua_State *L) {
 	luaL_argcheck (L, cur != NULL, 1, LUASQL_PREFIX"cursor expected");
 	if (cur->closed) {
 		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushstring(L, "cursor is already closed");
+		return 2;
 	}
 	cur_nullify (L, cur);
 	lua_pushboolean (L, 1);
@@ -430,10 +431,15 @@ static int conn_close (lua_State *L) {
 	conn_data *conn=(conn_data *)luaL_checkudata(L, 1, LUASQL_CONNECTION_MYSQL);
 	luaL_argcheck (L, conn != NULL, 1, LUASQL_PREFIX"connection expected");
 	if (conn->closed) {
-		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushboolean(L, 0);
+		lua_pushstring(L, "Connection is already closed");
+		return 2;
 	}
-	conn_gc (L);
+	
+	conn->closed = 1;
+	luaL_unref (L, LUA_REGISTRYINDEX, conn->env);
+	mysql_close (conn->my_conn);
+
 	lua_pushboolean (L, 1);
 	return 1;
 }
@@ -623,7 +629,8 @@ static int env_close (lua_State *L) {
 	luaL_argcheck (L, env != NULL, 1, LUASQL_PREFIX"environment expected");
 	if (env->closed) {
 		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushstring(L, "env is already closed");
+		return 2;
 	}
 	mysql_library_end();
 	env->closed = 1;
@@ -638,14 +645,14 @@ static int env_close (lua_State *L) {
 static void create_metatables (lua_State *L) {
     struct luaL_Reg environment_methods[] = {
         {"__gc", env_gc},
-		{"__close", env_close},
+		{"__close", env_gc},
         {"close", env_close},
         {"connect", env_connect},
 		{NULL, NULL},
 	};
     struct luaL_Reg connection_methods[] = {
         {"__gc", conn_gc},
-		{"__close", conn_close},
+		{"__close", conn_gc},
         {"close", conn_close},
         {"ping", conn_ping},
         {"escape", escape_string},
@@ -658,7 +665,7 @@ static void create_metatables (lua_State *L) {
     };
     struct luaL_Reg cursor_methods[] = {
         {"__gc", cur_gc},
-		{"__close", cur_close},
+		{"__close", cur_gc},
         {"close", cur_close},
         {"getcolnames", cur_getcolnames},
         {"getcoltypes", cur_getcoltypes},

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -399,7 +399,8 @@ static int cur_close (lua_State *L) {
 	luaL_argcheck (L, cur != NULL, 1, LUASQL_PREFIX"cursor expected");
 	if (cur->closed) {
 		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushstring(L, "cursor is already closed");
+		return 2;
 	}
 
 	/* Deallocate buffers. */
@@ -520,11 +521,15 @@ static int conn_close (lua_State *L) {
 	conn_data *conn = (conn_data *)luaL_checkudata (L, 1, LUASQL_CONNECTION_OCI8);
 	luaL_argcheck (L, conn != NULL, 1, LUASQL_PREFIX"connection expected");
 	if (conn->closed) {
-		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushboolean(L, 0);
+    	lua_pushstring(L, "Connection is already closed");
+    	return 2;
 	}
-	if (conn->cur_counter > 0)
-		return luaL_error (L, LUASQL_PREFIX"there are open cursors");
+	if (conn->cur_counter > 0){
+		lua_pushboolean(L, 0);
+		lua_pushstring(L, "There are open cursors");
+		return 2;
+	}
 
 	/* Nullify structure fields. */
 	conn->closed = 1;
@@ -769,10 +774,14 @@ static int env_close (lua_State *L) {
 	luaL_argcheck (L, env != NULL, 1, LUASQL_PREFIX"environment expected");
 	if (env->closed) {
 		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushstring(L, "env is already closed");
+		return 2;
 	}
-	if (env->conn_counter > 0)
-		return luaL_error (L, LUASQL_PREFIX"there are open connections");
+	if (env->conn_counter > 0){
+		lua_pushboolean(L, 0);
+    	lua_pushstring(L, "There are open connections");
+    	return 2;
+	}
 
 	env->closed = 1;
 	/* desalocar: env->errhp e env->envhp */

--- a/src/ls_odbc.c
+++ b/src/ls_odbc.c
@@ -503,7 +503,8 @@ static int cur_close (lua_State *L)
 
 	if (cur->closed) {
 		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushstring(L, "cursor is already closed");
+		return 2;
 	}
 
 	if((res = cur_shut(L, cur)) != 0) {
@@ -637,11 +638,14 @@ static int conn_close (lua_State *L)
 	conn_data *conn = (conn_data *)luaL_checkudata(L,1,LUASQL_CONNECTION_ODBC);
 	luaL_argcheck (L, conn != NULL, 1, LUASQL_PREFIX"connection expected");
 	if (conn->closed) {
-		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushboolean(L, 0);
+    	lua_pushstring(L, "Connection is already closed");
+    	return 2;
 	}
 	if (conn->lock > 0) {
-		return luaL_error (L, LUASQL_PREFIX"there are open statements/cursors");
+		lua_pushboolean(L, 0);
+		lua_pushstring(L, "There are open statements/cursors");
+		return 2;
 	}
 
 	/* Decrement connection counter on environment object */
@@ -1105,10 +1109,13 @@ static int env_close (lua_State *L)
 	luaL_argcheck (L, env != NULL, 1, LUASQL_PREFIX"environment expected");
 	if (env->closed) {
 		lua_pushboolean (L, 0);
-		return 1;
+		lua_pushstring(L, "env is already closed");
+		return 2;
 	}
 	if (env->lock > 0) {
-		return luaL_error (L, LUASQL_PREFIX"there are open connections");
+		lua_pushboolean(L, 0);
+    	lua_pushstring(L, "There are open connections");
+    	return 2;
 	}
 
 	env->closed = 1;

--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -174,7 +174,7 @@ static int cur_close (lua_State *L) {
 		lua_pushboolean (L, 0);
 		return 1;
 	}
-	cur_nullify (L, cur); /* == cur_gc (L); */
+	cur_nullify (L, cur); 
 	lua_pushboolean (L, 1);
 	return 1;
 }
@@ -353,7 +353,10 @@ static int conn_close (lua_State *L) {
 		lua_pushboolean (L, 0);
 		return 1;
 	}
-	conn_gc (L);
+	conn->closed = 1;
+	luaL_unref (L, LUA_REGISTRYINDEX, conn->env);
+	PQfinish (conn->pg_conn);
+
 	lua_pushboolean (L, 1);
 	return 1;
 }
@@ -549,7 +552,7 @@ static int env_close (lua_State *L) {
 		lua_pushboolean (L, 0);
 		return 1;
 	}
-	env_gc (L);
+	env->closed = 1;
 	lua_pushboolean (L, 1);
 	return 1;
 }
@@ -562,14 +565,14 @@ static int env_close (lua_State *L) {
 static void create_metatables (lua_State *L) {
 	struct luaL_Reg environment_methods[] = {
 		{"__gc",    env_gc},
-		{"__close", env_close},
+		{"__close", env_gc},
 		{"close",   env_close},
 		{"connect", env_connect},
 		{NULL, NULL},
 	};
 	struct luaL_Reg connection_methods[] = {
 		{"__gc",          conn_gc},
-		{"__close", 	  conn_close},
+		{"__close", 	  conn_gc},
 		{"close",         conn_close},
 		{"escape",        conn_escape},
 		{"execute",       conn_execute},
@@ -580,7 +583,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg cursor_methods[] = {
 		{"__gc",        cur_gc},
-		{"__close", 	cur_close},
+		{"__close", 	cur_gc},
 		{"close",       cur_close},
 		{"getcolnames", cur_getcolnames},
 		{"getcoltypes", cur_getcoltypes},

--- a/src/ls_sqlite.c
+++ b/src/ls_sqlite.c
@@ -278,10 +278,7 @@ static int create_cursor(lua_State *L, int o, conn_data *conn,
 static int conn_gc(lua_State *L) {
 	conn_data *conn = (conn_data *)luaL_checkudata(L, 1, LUASQL_CONNECTION_SQLITE);
 	if (conn != NULL && !(conn->closed)) {
-		if (conn->cur_counter > 0) {
-			return luaL_error (L, LUASQL_PREFIX"there are open cursors");
-		}
-
+		
 		/* Nullify structure fields. */
 		conn->closed = 1;
 		luaL_unref(L, LUA_REGISTRYINDEX, conn->env);
@@ -297,11 +294,24 @@ static int conn_gc(lua_State *L) {
 static int conn_close(lua_State *L) {
 	conn_data *conn = (conn_data *)luaL_checkudata(L, 1, LUASQL_CONNECTION_SQLITE);
 	luaL_argcheck (L, conn != NULL, 1, LUASQL_PREFIX"connection expected");
-	if (conn->closed) {
+	if (conn->closed)
+	{
 		lua_pushboolean(L, 0);
-		return 1;
+		lua_pushstring(L, "Connection is already closed");
+		return 2;
 	}
-	conn_gc(L);
+	
+	if (conn->cur_counter > 0)
+	{
+		lua_pushboolean(L, 0);
+		lua_pushstring(L, "There are open cursors");
+		return 2;
+	}
+	
+	conn->closed = 1;
+	luaL_unref(L, LUA_REGISTRYINDEX, conn->env);
+	sqlite3_close(conn->sql_conn);
+	
 	lua_pushboolean(L, 1);
 	return 1;
 }
@@ -506,7 +516,7 @@ static int env_close (lua_State *L) {
 		lua_pushboolean(L, 0);
 		return 1;
 	}
-	env_gc(L);
+	env->closed = 1;
 	lua_pushboolean(L, 1);
 	return 1;
 }
@@ -530,14 +540,14 @@ static int conn_escape(lua_State *L) {
 static void create_metatables (lua_State *L) {
 	struct luaL_Reg environment_methods[] = {
 		{"__gc", env_gc},
-		{"__close", env_close},
+		{"__close", env_gc},
 		{"close", env_close},
 		{"connect", env_connect},
 		{NULL, NULL},
 	};
 	struct luaL_Reg connection_methods[] = {
 		{"__gc", conn_gc},
-		{"__close", conn_close},
+		{"__close", conn_gc},
 		{"close", conn_close},
 		{"escape", conn_escape},
 		{"execute", conn_execute},
@@ -548,7 +558,7 @@ static void create_metatables (lua_State *L) {
 	};
 	struct luaL_Reg cursor_methods[] = {
 		{"__gc", cur_gc},
-		{"__close", cur_close},
+		{"__close", cur_gc},
 		{"close", cur_close},
 		{"getcolnames", cur_getcolnames},
 		{"getcoltypes", cur_getcoltypes},


### PR DESCRIPTION

## Summary
This pull request enhances the resource cleanup methods for the all LuaSQL drivers -  SQLite3, MySQL, SQLite, Firebird, OCI8, ODBC and PostgreSQL

### Proposed Changes
1. **Update of `__close` Metamethod:**
   - The `__close` metamethods of LuaSQL objects have been updated with their respective `__gc` methods.
   - **Rationale:** The `__close` and `__gc` metamethods should only be invoked by the Lua interpreter. The `:close()` method, on the other hand, is intended for use by the programmer. This change ensures correct and consistent handling of resource cleanup by distinguishing between interpreter-managed and programmer-managed methods.

2. **Refinement of `close()` Method:**
   - The `:close()` method now returns `false` instead of raising an error when there are related open objects.
   - **Rationale:** This adjustment prevents unnecessary interruptions in program execution. By returning `false`, the method indicates the presence of related open objects without terminating the operation, allowing better error handling.

3. **Enhanced Return Values for `close()` Method:**
   - The `:close()` method now returns two values: an `int` and a `string`
   - **Rationale:** This enhancement provides better insight into the state of open objects, offering more information to developers for debugging and resource management.
   
4. **Bug Fix: Prevent `_gc` from Being Called by `:close()` Method**
   - Fixed an issue where the `_gc` method was improperly invoked when `:close()` was called.
   - **Update:** The `_gc` method no longer checks for the open object counter as it should only be concerned with garbage collection, not object state.
   - **Rationale:** The `_gc` method should be called only by the Lua interpreter during garbage collection, and it should not interfere with or rely on the open object counter to avoid unintended behavior.
