### PR TITLE
odbc: Fix build when UNICODE is defined

### DIFF
--- a/src/ls_odbc.c
+++ b/src/ls_odbc.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <time.h>
 
+#define SQL_NOUNICODEMAP
 #if defined(_WIN32)
 #include <windows.h>
 #include <sqlext.h>


### PR DESCRIPTION
When `UNICODE` is defined, SQL* functions are mapped to -W functions which require `wchar_t` input. Define `SQL_NOUNICODEMAP` to disable the mapping.