### PR TITLE
Implement dates and timestamps in OCI driver

### DIFF
--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -47,6 +47,12 @@ typedef union {
 	int     i;
 	char   *s;
 	double  d;
+#ifdef SQLT_DAT
+	OCIDate date;
+#endif
+#ifdef SQLT_TIMESTAMP
+	OCIDateTime *datetime;
+#endif
 } column_value;
 
 
@@ -209,6 +215,68 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 				SQLT_STR /*col->type*/, (dvoid *)&(col->null), (ub2 *)0,
 				(ub2 *)0, (ub4) OCI_DEFAULT), cur->errhp);
 			break;
+#ifdef SQLT_DAT
+		case SQLT_DAT:
+			ASSERT (L, OCIDefineByPos (cur->stmthp, &(col->define),
+				cur->errhp, (ub4)i, &(col->val.date), sizeof(col->val.date),
+				SQLT_ODT /*col->type*/, (dvoid *)&(col->null), (ub2 *)0,
+				(ub2 *)0, (ub4) OCI_DEFAULT), cur->errhp);
+			break;
+#endif
+#ifdef SQLT_TIMESTAMP
+		case SQLT_TIMESTAMP: {
+			env_data *env;
+			conn_data *conn;
+			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
+			conn = (conn_data *)lua_touserdata (L, -1);
+			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
+			env = (env_data *)lua_touserdata (L, -1);
+			lua_pop (L, 2);
+			ASSERT (L, OCIDescriptorAlloc (env->envhp,(dvoid*)&(col->val.datetime),
+				OCI_DTYPE_TIMESTAMP, 0, (void **)0), cur->errhp);
+			ASSERT (L, OCIDefineByPos (cur->stmthp, &(col->define), cur->errhp,
+				(ub4)i, &(col->val.datetime), sizeof(col->val.datetime),
+				SQLT_TIMESTAMP, (dvoid *)&(col->null), (ub2 *)0, (ub2 *)0, (ub4)
+				OCI_DEFAULT), cur->errhp);
+			break;
+		}
+#endif
+#ifdef SQLT_TIMESTAMP_TZ
+		case SQLT_TIMESTAMP_TZ: {
+			env_data *env;
+			conn_data *conn;
+			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
+			conn = (conn_data *)lua_touserdata (L, -1);
+			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
+			env = (env_data *)lua_touserdata (L, -1);
+			lua_pop (L, 2);
+			ASSERT (L, OCIDescriptorAlloc (env->envhp,(dvoid*)&(col->val.datetime),
+				OCI_DTYPE_TIMESTAMP_TZ, 0, (void **)0), cur->errhp);
+			ASSERT (L, OCIDefineByPos (cur->stmthp, &(col->define), cur->errhp,
+				(ub4)i, &(col->val.datetime), sizeof(col->val.datetime),
+				SQLT_TIMESTAMP_TZ, (dvoid *)&(col->null), (ub2 *)0, (ub2 *)0, (ub4)
+				OCI_DEFAULT), cur->errhp);
+			break;
+		}
+#endif
+#ifdef SQLT_TIMESTAMP_LTZ
+		case SQLT_TIMESTAMP_LTZ: {
+			env_data *env;
+			conn_data *conn;
+			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
+			conn = (conn_data *)lua_touserdata (L, -1);
+			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
+			env = (env_data *)lua_touserdata (L, -1);
+			lua_pop (L, 2);
+			ASSERT (L, OCIDescriptorAlloc (env->envhp,(dvoid*)&(col->val.datetime),
+				OCI_DTYPE_TIMESTAMP_LTZ, 0, (void **)0), cur->errhp);
+			ASSERT (L, OCIDefineByPos (cur->stmthp, &(col->define), cur->errhp,
+				(ub4)i, &(col->val.datetime), sizeof(col->val.datetime),
+				SQLT_TIMESTAMP_LTZ, (dvoid *)&(col->null), (ub2 *)0, (ub2 *)0,
+				(ub4) OCI_DEFAULT), cur->errhp);
+			break;
+		}
+#endif
 		case SQLT_NUM:
 		case SQLT_FLT:
 		case SQLT_INT:
@@ -262,6 +330,28 @@ static int free_column_buffers (lua_State *L, cur_data *cur, int i) {
 		case SQLT_AVC:
 			free(col->val.s);
 			break;
+#ifdef SQLT_DAT
+		case SQLT_DAT:
+			break;
+#endif
+#ifdef SQLT_TIMESTAMP
+		case SQLT_TIMESTAMP:
+			ASSERT (L, OCIDescriptorFree (col->val.datetime,
+				OCI_DTYPE_TIMESTAMP), cur->errhp);
+			break;
+#endif
+#ifdef SQLT_TIMESTAMP_TZ
+		case SQLT_TIMESTAMP_TZ:
+			ASSERT (L, OCIDescriptorFree (col->val.datetime,
+				OCI_DTYPE_TIMESTAMP_TZ), cur->errhp);
+			break;
+#endif
+#ifdef SQLT_TIMESTAMP_LTZ
+		case SQLT_TIMESTAMP_LTZ:
+			ASSERT (L, OCIDescriptorFree (col->val.datetime,
+				OCI_DTYPE_TIMESTAMP_LTZ), cur->errhp);
+			break;
+#endif
 		case SQLT_CLOB:
 			ASSERT (L, OCIDescriptorFree (col->val.s,
 				OCI_DTYPE_LOB), cur->errhp);
@@ -300,6 +390,39 @@ static int pushvalue (lua_State *L, cur_data *cur, int i) {
 		case SQLT_AVC:
 			lua_pushstring (L, (char *)(col->val.s));
 			break;
+#ifdef SQLT_DAT
+		case SQLT_DAT: {
+			text buf[65];
+			ub4 buflen = sizeof(buf);
+			ASSERT (L, OCIDateToText (cur->errhp, &(col->val.date), NULL, 0, NULL, 0,
+				&buflen, buf), cur->errhp);
+			lua_pushstring (L, (char *)(buf));
+			break;
+		}
+#endif
+#ifdef SQLT_TIMESTAMP_LTZ
+		case SQLT_TIMESTAMP_LTZ:
+#endif
+#ifdef SQLT_TIMESTAMP_TZ
+		case SQLT_TIMESTAMP_TZ:
+#endif
+#ifdef SQLT_TIMESTAMP
+		case SQLT_TIMESTAMP: {
+			conn_data *conn;
+			env_data *env;
+			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
+			conn = lua_touserdata (L, -1);
+			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
+			env = lua_touserdata (L, -1);
+			lua_pop (L, 2);
+			text buf[65];
+			ub4 buflen = sizeof(buf);
+			ASSERT (L, OCIDateTimeToText (env->envhp, cur->errhp, col->val.datetime,
+				NULL, 0, 6, NULL, 0, &buflen, buf), cur->errhp);
+			lua_pushstring (L, (char *)(buf));
+			break;
+		}
+#endif
 		case SQLT_CLOB: {
 			ub4 lob_len;
 			conn_data *conn;
@@ -464,6 +587,20 @@ static char *getcolumntype (column_data *col) {
 		case SQLT_AFC:
 		case SQLT_AVC:
 			return "string";
+#ifdef SQLT_DAT
+		case SQLT_DAT:
+			return "date";
+#endif
+#ifdef SQLT_TIMESTAMP_LTZ
+		case SQLT_TIMESTAMP_LTZ:
+#endif
+#ifdef SQLT_TIMESTAMP_TZ
+		case SQLT_TIMESTAMP_TZ:
+#endif
+#ifdef SQLT_TIMESTAMP
+		case SQLT_TIMESTAMP:
+			return "timestamp";
+#endif
 		case SQLT_NUM:
 		case SQLT_FLT:
 		case SQLT_INT:


### PR DESCRIPTION
It is now possible to directly query DATE and TIMESTAMP data types.

There is no direct support for these types in the original OCI interface version 8, so the code is guarded by ifdef checks.

Unfortunately, there is no interface to query the buffer size required for output strings. In order not to overcomplicate the code, a conservative size of 65 bytes (including NUL) was chosen. The "fsprec" parameter is not specified clearly, so a value of "6" was chosen for microsecond precision.

The code was compiled using a current [Oracle Instant Client SDK](https://www.oracle.com/database/technologies/instant-client/downloads.html) on Arch Linux using Lua 5.4.
Tests were performed by starting a [container](https://hub.docker.com/r/gvenzl/oracle-xe) using `podman` and running the following Lua script:
```lua
-- $ podman run -d -p 1521:1521 -e ORACLE_PASSWORD=test -e APP_USER_PASSWORD=test -e APP_USER=test docker://docker.io/gvenzl/oracle-xe
-- $ NLS_DATE_FORMAT='yyyy-mm-dd"T"hh24:mi:ss' NLS_TIMESTAMP_FORMAT='yyyy-mm-dd"T"hh24:mi:ss.ff6' NLS_TIMESTAMP_TZ_FORMAT='yyyy-mm-dd"T"hh24:mi:ss.ff6TZH:TZM' lua test.lua

oci8_driver = require "luasql.oci8"
env = oci8_driver.oci8()
con = env:connect('localhost:1521/XEPDB1', 'test', 'test')

res = con:execute"DROP TABLE people"
res = assert (con:execute('CREATE TABLE people( bday DATE )'))

list = {
  { bday="2025-05-31T13:38:24" },
  { bday="1900-01-01T00:00:00" },
}
for i, p in pairs (list) do
  res = assert (con:execute(string.format([[
    INSERT INTO people
    VALUES (TO_DATE('%s', '%s'))]], p.bday, os.getenv('NLS_DATE_FORMAT'))
  ))
end
res = assert (con:execute('INSERT INTO people VALUES (SYSDATE)'))

cur = assert (con:execute"SELECT bday FROM people")
row = cur:fetch ({}, "a")
while row do
  print(string.format("BDay: %s", row.bday))
  row = cur:fetch (row, "a")
end

res = con:execute"DROP TABLE people"
res = assert (con:execute("CREATE TABLE people( bday TIMESTAMP )"))
list = {
  { bday="2025-05-31T13:38:24.464966" },
  { bday="1900-01-01T00:00:00.000000" },
}
for i, p in pairs (list) do
  res = assert (con:execute(string.format([[
    INSERT INTO people
    VALUES (TO_TIMESTAMP('%s', '%s'))]], p.bday, os.getenv('NLS_TIMESTAMP_FORMAT'))
  ))
end
res = assert (con:execute("INSERT INTO people VALUES (SYSTIMESTAMP)"))

cur = assert (con:execute"SELECT bday FROM people")
row = assert ( cur:fetch ({}, "a"))
while row do
  print(string.format("BDay: %s", row.bday))
  row = cur:fetch (row, "a")
end

res = con:execute"DROP TABLE people"
res = assert (con:execute("CREATE TABLE people( bday TIMESTAMP WITH TIME ZONE )"))
list = {
  { bday="1950-02-03T05:06:40.000000+02:00" },
  { bday="1900-01-01T00:00:00.000000-04:00" },
}
for i, p in pairs (list) do
  res = assert (con:execute(string.format([[
    INSERT INTO people
    VALUES (TO_TIMESTAMP_TZ('%s', '%s'))]], p.bday, os.getenv('NLS_TIMESTAMP_TZ_FORMAT'))
  ))
end
res = assert (con:execute("INSERT INTO people VALUES (SYSTIMESTAMP)"))

cur = assert (con:execute"SELECT bday FROM people")
row = cur:fetch ({}, "a")
while row do
  print(string.format("BDay: %s", row.bday))
  row = cur:fetch (row, "a")
end

res = con:execute"DROP TABLE people"
res = assert (con:execute("CREATE TABLE people(bday TIMESTAMP WITH LOCAL TIME ZONE)"))
list = {
  { bday="1950-02-03T05:06:00.100000" },
  { bday="1900-01-01T00:00:00.000000" },
}
for i, p in pairs (list) do
  res = assert (con:execute(string.format([[
    INSERT INTO people
    VALUES (TO_TIMESTAMP('%s', '%s'))]], p.bday, os.getenv('NLS_TIMESTAMP_FORMAT'))
  ))
end
res = assert (con:execute("INSERT INTO people VALUES (SYSTIMESTAMP)"))

cur = assert (con:execute"SELECT bday FROM people")
row = cur:fetch ({}, "a")
while row do
  print(string.format("BDay: %s", row.bday))
  row = cur:fetch (row, "a")
end
```
Output
```
BDay: 2025-05-31T13:38:24
BDay: 1900-01-01T00:00:00
BDay: 2025-06-01T08:55:21
BDay: 2025-05-31T13:38:24.464966
BDay: 1900-01-01T00:00:00.000000
BDay: 2025-06-01T08:55:21.364331
BDay: 1950-02-03T05:06:40.000000+02:00
BDay: 1900-01-01T00:00:00.000000-04:00
BDay: 2025-06-01T08:55:21.373072+00:00
BDay: 1950-02-03T05:06:00.100000
BDay: 1900-01-01T00:00:00.000000
BDay: 2025-06-01T10:55:21.381021
```